### PR TITLE
Add course name to overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "keywords": [
     "d2l",
-  	"course",
+    "course",
     "homepage",
     "banner"
   ],
@@ -39,8 +39,8 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
-    "d2l-typography": "^5.2.2",
+    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.3",
+    "d2l-typography": "^5.2.4",
     "iron-a11y-announcer": "^1.0.5",
     "iron-a11y-keys": "^1.0.6",
     "iron-input": "^1.0.10",

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#~0.10.0",
-    "d2l-ajax": "^3.2.3",
+    "d2l-ajax": "^3.2.5",
     "d2l-alert": "git://github.com/Brightspace/alert.git#^0.0.1",
     "d2l-colors": "^2.2.3",
     "d2l-dropdown": "^5.0.0",

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -16,6 +16,7 @@
 				left: 0;
 				z-index: 1;
 				@apply(--d2l-body-standard-text);
+				word-wrap: break word;
 			}
 
 			.d2l-image-banner-overlay-content {
@@ -54,6 +55,7 @@
 				-webkit-box-orient: vertical;
 				display: -webkit-box;
 				overflow: hidden;
+				cursor: default;
 			}
 
 		</style>

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -20,7 +20,6 @@
 
 			.d2l-image-banner-overlay-content {
 				opacity: 0;
-				transition: opacity 2s;
 				width: 100%;
 				height: 100%;
 			}
@@ -37,18 +36,22 @@
 			}
 
 			.d2l-image-banner-course-name {
+				position: absolute;
+				bottom: 0;
 				width: 100%;
-				height: 100%;
-				background: linear-gradient(rgba(0, 0, 0, 0) 17.5%, black);
+				background: linear-gradient(rgba(0, 0, 0, 0), black);
+				padding-top: 2.8rem;
+				transform: scale3d(1,1,1);
 			}
 
 			#courseName {
 				color: var(--d2l-color-white);
-				height: initial;
-				position: absolute;
-				bottom: 0;
 				padding: 0 30px;
     			box-sizing: border-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
+				display: -webkit-box;
+				overflow: hidden;
 			}
 
 		</style>

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -39,14 +39,16 @@
 				position: absolute;
 				bottom: 0;
 				width: 100%;
-				background: linear-gradient(rgba(0, 0, 0, 0), black);
-				padding-top: 2.8rem;
+				background: linear-gradient(rgba(0, 0, 0, 0), black 200px);
+				padding-top: 3.35rem;
+				max-height: 100%;
 				transform: scale3d(1,1,1);
 			}
 
 			#courseName {
 				color: var(--d2l-color-white);
 				padding: 0 30px;
+				margin-top: 0;
     			box-sizing: border-box;
 				-webkit-line-clamp: 2;
 				-webkit-box-orient: vertical;

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -1,9 +1,13 @@
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../../d2l-typography/d2l-typography.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 
 <dom-module id="d2l-image-banner-overlay">
 	<template>
-		<style include="d2l-typography-shared-styles">
+		<style include="d2l-typography d2l-typography-shared-styles">
 			:host {
 				position: absolute;
 				height: 100%;
@@ -11,22 +15,76 @@
 				top: 0;
 				left: 0;
 				z-index: 1;
+				@apply(--d2l-body-standard-text);
 			}
 
-			.d2l-image-banner-overlay {
+			.d2l-image-banner-overlay-content {
+				opacity: 0;
+				transition: opacity 2s;
 				width: 100%;
 				height: 100%;
 			}
+
+			.d2l-image-banner-overlay-content-shown {
+				animation-name: shown;
+				animation-duration: 0.5s;
+				animation-fill-mode: forwards;
+			}
+
+			@keyframes shown {
+				0% { opacity: 0 }
+				100% { opacity: 1; }
+			}
+
+			.d2l-image-banner-course-name {
+				width: 100%;
+				height: 100%;
+				background: linear-gradient(rgba(0, 0, 0, 0) 17.5%, black);
+			}
+
+			#courseName {
+				color: var(--d2l-color-white);
+				height: initial;
+				position: absolute;
+				bottom: 0;
+				padding: 0 30px;
+    			box-sizing: border-box;
+			}
+
 		</style>
 
-		<div class="d2l-image-banner-overlay">
+		<d2l-ajax auto
+			url="[[organizationUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onOrganizationResponse">
+		</d2l-ajax>
+
+		<div id="overlayContent" class="d2l-image-banner-overlay-content d2l-typography">
+			<div class="d2l-image-banner-course-name">
+				<h1 id="courseName" class="d2l-heading-1">[[_courseName]]</h1>
+			</div>
 		</div>
 	</template>
 	<script>
 		'use strict';
 		Polymer({
 			is: 'd2l-image-banner-overlay',
-			properties: {}
+			properties: {
+				organizationUrl: String,
+				_courseName: String
+			},
+			ready: function() {
+				Polymer.dom(this.$.overlayContent).classList.add('d2l-image-banner-overlay-content-shown');
+			},
+			_onOrganizationResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var organization = parser.parse(response.detail.xhr.response);
+					if (organization && organization.properties) {
+						this._courseName = organization.properties.name;
+					}
+				}
+			}
 		});
 	</script>
 </dom-module>

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -16,7 +16,7 @@
 				left: 0;
 				z-index: 1;
 				@apply(--d2l-body-standard-text);
-				word-wrap: break word;
+				word-wrap: break-word;
 			}
 
 			.d2l-image-banner-overlay-content {


### PR DESCRIPTION
This is for [US81136](https://rally1.rallydev.com/#/87829734000d/detail/userstory/85641725212). It requires [this LMS PR](https://git.dev.d2l/projects/CORE/repos/platformtools/pull-requests/1341/overview) in order to get the organization url.

Acceptance Criteria:
- [x] Course name for the organization is displayed 40px Lato regular white as per https://d2l.invisionapp.com/boards/DX346WGJSE4QN#/5234416/159770705
- [x] Course name shrinks responsively to 30px Lato (standard D2L Typography)
- [x] Image has a gradient overlay in order to contrast the white text, as per https://d2l.invisionapp.com/boards/DX346WGJSE4QN#/5234416/159771067
- [x] Text and gradient fade in gracefully
- [x] Text and gradient handle RTL appropriately
- [x] Gradient moves 'up' with text as additional lines of text are added such that the first pixel above a lowercase 'o' on the top line is always [WCAG AA for large text](http://webaim.org/resources/contrastchecker/) (the lightest allowable value is 949494 which is what I measured regardless of the number of lines).
- [x] Text caps to 2 lines with ellipsis on Chrome and Safari (desktop and mobile)
- [x] Text grows infinitely on Firefox, IE, and Edge. When it reaches the top of the image any remaining text will overflow below (truncate)