### PR TITLE
Make the course side margins scale with others on the page

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -48,7 +48,7 @@
 
 			#courseName {
 				color: var(--d2l-color-white);
-				padding: 0 30px;
+				padding: 0 2.439%;
 				margin-top: 0;
     			box-sizing: border-box;
 				-webkit-line-clamp: 2;
@@ -56,6 +56,13 @@
 				display: -webkit-box;
 				overflow: hidden;
 				cursor: default;
+			}
+
+			@media (max-width: 615px) {
+				#courseName {
+					padding-left: 15px;
+					padding-right: 15px;
+				}
 			}
 
 		</style>


### PR DESCRIPTION
[US82411](https://rally1.rallydev.com/#/87829734000/detail/userstory/92371493252)

The `d2l-main-page-padding` values are percentage based which cause the margins of widgets on the homepage to expand/shrink as the viewport width changes (to a point; there is a media query at 615px that effectively creates a min-width of 15px). We want the side margins on the course name to flow in the same manner.