### PR TITLE
slowed the animation for the overlay content to be a little less harsh

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -27,7 +27,7 @@
 
 			.d2l-image-banner-overlay-content-shown {
 				animation-name: shown;
-				animation-duration: 0.5s;
+				animation-duration: 1.2s;
 				animation-fill-mode: forwards;
 			}
 


### PR DESCRIPTION
[US82413](https://rally1.rallydev.com/#/87829734000/detail/userstory/92371504628)

So daylight demo seems bizarrely inconsistent with regards to response times. It was determined that in cases of slow loading of the organization information it might be more palatable with a slower fade-in animation, as the existing .5s animation seemed to get lost (possibly just in the painting of the control or else because the white text is so stark against the background that your eyes don't notice the quick fade).

Regardless, the decision was made to increase the fade to 1.2s and then see how that feels.