### PR TITLE
Make the gradient a static size for non-webkit

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -40,14 +40,27 @@
 				100% { opacity: 1; }
 			}
 
+			.d2l-image-banner-course-name-container {
+				background: linear-gradient(rgba(0, 0, 0, 0) 17.5%, black);
+			}
+
 			.d2l-image-banner-course-name {
 				position: absolute;
 				bottom: 0;
 				width: 100%;
-				background: linear-gradient(rgba(0, 0, 0, 0), black 200px);
-				padding-top: 3.35rem;
 				max-height: 100%;
 				transform: scale3d(1,1,1);
+			}
+
+			@supports (-webkit-line-clamp: 2) {
+				.d2l-image-banner-course-name-container {
+					background: initial;
+				}
+
+				.d2l-image-banner-course-name {
+					background: linear-gradient(rgba(0, 0, 0, 0), black 200px);
+					padding-top: 3.35rem;
+				}
 			}
 
 			#courseName {

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -40,23 +40,17 @@
 				100% { opacity: 1; }
 			}
 
-			.d2l-image-banner-course-name-container {
-				background: linear-gradient(rgba(0, 0, 0, 0) 17.5%, black);
-			}
-
 			.d2l-image-banner-course-name {
 				position: absolute;
 				bottom: 0;
 				width: 100%;
+				background: linear-gradient(rgba(0,0,0,0),rgba(0,0,0,.95) 130%);
+				padding-top: 3.5rem;
 				max-height: 100%;
 				transform: scale3d(1,1,1);
 			}
 
 			@supports (-webkit-line-clamp: 2) {
-				.d2l-image-banner-course-name-container {
-					background: initial;
-				}
-
 				.d2l-image-banner-course-name {
 					background: linear-gradient(rgba(0, 0, 0, 0), black 200px);
 					padding-top: 3.35rem;


### PR DESCRIPTION
[US82412](https://rally1.rallydev.com/#/87829734000/detail/userstory/92371496824)

**Problem**
Because IE, Edge, and FF do not support `-webkit-line-clamp` we cannot restrict the course name text to a max of 2 lines. As such, using the current method of sizing the gradient to grow or shrink with the text leads to an undesirable result when there are more then 2 lines of text (basically the entire image is lost behind the dark gradient).

**Acceptance Criteria**
For browsers that don't support `-webkit-line-clamp` (so IE, Edge, and FF) the gradient should be a static size, which is to say it should match the original mocks where it was optimized for a two-line course name (see attached).