### PR TITLE
update version of organization-hm-behavior to be the correct one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
     "d2l-loading-spinner": "^5.0.0",
     "d2l-menu": "^0.3.0",
     "d2l-offscreen": "^2.2.2",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#~0.0.1",
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#~1.0.0",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.3",
     "d2l-typography": "^5.3.0",


### PR DESCRIPTION
The update of this on BSI failed because it couldn't find a good version for d2l-hm-behavior

https://github.com/Brightspace/brightspace-integration/pull/512