### PR TITLE
Fix the loading spinner

### DIFF
--- a/src/d2l-image-banner-overlay-styles.html
+++ b/src/d2l-image-banner-overlay-styles.html
@@ -196,7 +196,8 @@
 				margin: auto;
 			}
 
-			.change-image-loading d2l-loading-spinner {
+			.change-image-loading d2l-loading-spinner,
+			.loading-overlay-shown .loading-overlay d2l-loading-spinner {
 				display: flex;
 			}
 


### PR DESCRIPTION
Found this when fooling around in IE

The change-image animation changed how the loading spinner was hidden, so I needed to add one more selector for the "please wait as we remove your banner" spinner or it would never come out of hiding