### PR TITLE
US84675 - Remove d2l-siren-parser-ui

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,6 @@
     "d2l-offscreen": "^2.2.2",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#~1.0.0",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.3",
     "d2l-typography": "^5.3.0",
     "iron-a11y-announcer": "^1.0.5",
     "iron-a11y-keys": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "scripts": {
     "postinstall": "bower install",
-    "test": "npm run test:lint:js && npm run test:lint:wc && wct",
+    "test": "npm run test:lint:js && wct",
     "test:lint:js": "eslint --ext .js,.html .",
-    "test:lint:wc": "polylint --no-recursion --input src/*.html",
     "test:no-lint": "wct -p"
   },
   "homepage": "https://github.com/Brightspace/d2l-image-banner-overlay",

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-performance/d2l-performance.html">
-<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="d2l-image-banner-overlay-styles.html">
 <link rel="import" href="localize-behavior.html">
 
@@ -76,6 +75,7 @@
 			<span>[[_errorAlertStart]]</span><a is="d2l-link" href="javascript:window.location.reload(true)">[[localize('refreshAndTryAgain')]]</a><span>[[_errorAlertEnd]]</span>
 		</d2l-alert>
 	</template>
+	<script src="https://s.brightspace.com/lib/siren-parser/5.2.2/siren-parser.js"></script>
 	<script>
 		'use strict';
 		Polymer({
@@ -118,8 +118,7 @@
 				document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
 			},
 			_onSetCourseImage: function(e) {
-				var parser = this._getParser();
-				var org = parser.parse(e.detail.organization);
+				var org = this._parseSiren(e.detail.organization);
 				if (!org.getLinkByRel) { return; }
 
 				var orgSelfLink = (org.getLinkByRel('self') || {}).href || '',
@@ -184,19 +183,15 @@
 			_getDefaultImageLink: function(image) {
 				return this.getDefaultImageLink(image, 'wide');
 			},
-			_parser: null,
-			_getParser: function() {
-				if (!this._parser) {
-					this._parser = document.createElement('d2l-siren-parser');
-				}
-				return this._parser;
+			_parseSiren: function(entity) {
+				return window.D2L.Hypermedia.Siren.Parser(entity);
 			},
 			_showDropdown: function(removeBannerAction) {
 				return !!removeBannerAction;
 			},
 			_onOrganizationResponse: function(response) {
 				if (response.detail.status === 200) {
-					var organization = this._getParser().parse(response.detail.xhr.response);
+					var organization = this._parseSiren(response.detail.xhr.response);
 					this._addPerfMark('org-response.parsed');
 					this._addPerfMeasure('ready-to-org-response-parsed', 'ready', 'org-response.parsed');
 
@@ -240,7 +235,7 @@
 				}
 			},
 			_onToggleBannerResponse: function(response) {
-				var organization = this._getParser().parse(response.detail.xhr.response) || {};
+				var organization = this._parseSiren(response.detail.xhr.response) || {};
 				this._addBannerAction = (organization.getActionByName('add-homepage-banner') || {}).href;
 				this._removeBannerAction = (organization.getActionByName('remove-homepage-banner') || {}).href;
 

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -75,7 +75,7 @@
 			<span>[[_errorAlertStart]]</span><a is="d2l-link" href="javascript:window.location.reload(true)">[[localize('refreshAndTryAgain')]]</a><span>[[_errorAlertEnd]]</span>
 		</d2l-alert>
 	</template>
-	<script src="https://s.brightspace.com/lib/siren-parser/5.2.2/siren-parser.js"></script>
+	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 	<script>
 		'use strict';
 		Polymer({
@@ -184,7 +184,7 @@
 				return this.getDefaultImageLink(image, 'wide');
 			},
 			_parseSiren: function(entity) {
-				return window.D2L.Hypermedia.Siren.Parser(entity);
+				return window.D2L.Hypermedia.Siren.Parse(entity);
 			},
 			_showDropdown: function(removeBannerAction) {
 				return !!removeBannerAction;


### PR DESCRIPTION
Unfortunately, there is a bug in polylint (https://github.com/PolymerLabs/polylint/issues/141) that doesn't allow for URLs to be used directly... which is a pretty big deal. Removing polylint because of this - it has arguable benefits anyway.