### PR TITLE
bump authify to fix 403s on non-canon calls to /organizations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#~0.10.0",
     "d2l-alert": "git://github.com/Brightspace/alert.git#^1.0.0",
-    "d2l-authify-import": "https://github.com/Brightspace/d2l-authify-import.git#^0.2.0",
+    "d2l-authify-import": "https://github.com/Brightspace/d2l-authify-import.git#^0.3.0",
     "d2l-colors": "^2.2.3",
     "d2l-dropdown": "^5.0.0",
     "d2l-icons": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -39,8 +39,10 @@
     "d2l-menu": "^0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#~1.0.0",
+    "d2l-performance": "^0.0.4",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-typography": "^5.3.0",
+    "fetch": "^2.0.3",
     "iron-a11y-announcer": "^1.0.5",
     "iron-a11y-keys": "^1.0.6",
     "iron-input": "^1.0.10",
@@ -49,6 +51,6 @@
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
     "iron-pages": "^1.0.8",
     "polymer": "^1.7.0",
-    "d2l-performance": "^0.0.4"
+    "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#~0.10.0",
     "d2l-alert": "git://github.com/Brightspace/alert.git#^1.0.0",
-    "d2l-authify-import": "https://github.com/Brightspace/d2l-authify-import.git#^0.3.0",
+    "d2l-authify-import": "https://github.com/Brightspace/d2l-authify-import.git#^0.4.0",
     "d2l-colors": "^2.2.3",
     "d2l-dropdown": "^5.0.0",
     "d2l-icons": "^3.0.0",

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
 <link rel="import" href="../../d2l-alert/d2l-alert.html">
 <link rel="import" href="../../d2l-authify-import/d2l-authify.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
@@ -70,6 +71,7 @@
 		</d2l-alert>
 	</template>
 	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
+	<script src="../bower_components/fetch/fetch.js"></script>
 	<script>
 		'use strict';
 		Polymer({


### PR DESCRIPTION
Discovered that if canonical namespaces were OFF the previous version of d2l-authify (0.2.0) did not send cookies so calls to relative urls would `403`. This bump implements the fix.

Acceptance Criteria:
- overlay should show correctly with canonical namespaces ON and OFF
- overlay toggle functionality (remove/undo) should work with canonical namespaces ON and OFF
- works in all browsers

TODO:

- [x] Update to `d2l-authify-import#0.4.0` once it exists (need this https://github.com/Brightspace/d2l-authify/pull/12)