### PR TITLE
Updating linear gradients to always be accessible

### DIFF
--- a/src/d2l-image-banner-overlay-styles.html
+++ b/src/d2l-image-banner-overlay-styles.html
@@ -37,7 +37,7 @@
 				position: absolute;
 				bottom: 0;
 				width: 100%;
-				background: linear-gradient(rgba(0,0,0,0),rgba(0,0,0,.95) 130%);
+				background: linear-gradient(rgba(0,0,0,0), #000 120%);
 				padding-top: 3.5rem;
 				max-height: 100%;
 				transform: scale3d(1,1,1);
@@ -45,7 +45,7 @@
 
 			@supports (-webkit-line-clamp: 2) {
 				.d2l-image-banner-course-name {
-					background: linear-gradient(rgba(0, 0, 0, 0), black 200px);
+					background: linear-gradient(rgba(0, 0, 0, 0), #000 267px);
 					padding-top: 3.35rem;
 				}
 			}


### PR DESCRIPTION
..with 1 or 2 lines of text, and no darker to match design.

Went over this with Jeff to confirm exact values in various scenarios.  Seems to be good.  We originally decided to update this because the gradient looked a little too dark sometimes.  However, when doing that we also noticed that the default gradient (for browsers that do not support text clamping) was not accessible enough (not dark enough).