### PR TITLE
Remove d2l-polymer-behaviors dependency since it is not used.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,6 @@
     "d2l-offscreen": "^2.2.4",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",
     "d2l-performance": "^0.0.4",
-    "d2l-polymer-behaviors": "<1.0.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.1",
     "d2l-typography": "^5.4.0",
     "fetch": "^2.0.3",


### PR DESCRIPTION
The `d2l-polymer-behaviors` dependency appears to not be used in this project.