### PR TITLE
Allow upload callback function to be provided

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "d2l-colors": "^2.3.0",
     "d2l-dropdown": "^5.0.6",
     "d2l-icons": "^3.2.0",
-    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^1.0.4",
+    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^1.1.0",
     "d2l-link": "^3.5.0",
     "d2l-loading-spinner": "^5.0.4",
     "d2l-menu": "^0.3.5",

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -72,7 +72,8 @@
 				organization="[[_organization]]"
 				user-id="[[userId]]"
 				tenant-id="[[tenantId]]"
-				telemetry-endpoint="[[telemetryEndpoint]]">
+				telemetry-endpoint="[[telemetryEndpoint]]"
+				course-image-upload-cb="[[courseImageUploadCb]]">
 			</d2l-basic-image-selector>
 		</d2l-simple-overlay>
 		<d2l-alert
@@ -104,6 +105,7 @@
 		Polymer({
 			is: 'd2l-image-banner-overlay',
 			properties: {
+				courseImageUploadCb: Function, // callback function for d2l-image-selector
 				organizationUrl: String, // url used to request organization information
 				imageCatalogLocation: String, // URL that is called by the widget to fetch results from the course image catalog
 				userId: String, // hashed userid to send to telemetry
@@ -134,6 +136,7 @@
 						iconName: ''
 					}
 				},
+				_shouldRefreshCourseImage: Boolean, // whether or not to refresh course image after getting org info
 				_nextImage: Object // when changing the banner image, the next image to show
 			},
 			behaviors: [
@@ -155,7 +158,25 @@
 				this._showBannerErrorAlert = false;
 				Polymer.dom(this.$.overlayContent).classList.add('d2l-image-banner-overlay-content-shown');
 				document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
+				this._getOrganizationInfo();
+			},
+			courseImageUploadCompleted: function(success) {
+				var overlayContent = this.$.overlayContent;
 
+				if (success) {
+					this.$['basic-image-selector-overlay'].close();
+					this.toggleClass('change-image-loading', true, overlayContent);
+					this._shouldRefreshCourseImage = true;
+					this._getOrganizationInfo();
+				} else {
+					this._displaySetImageResult(false);
+				}
+				this.focus();
+			},
+			focus: function() {
+				this.$$('button').focus();
+			},
+			_getOrganizationInfo: function() {
 				window.d2lauthify
 					.fetch(new Request(this.organizationUrl, {
 						headers: new Headers({
@@ -203,7 +224,7 @@
 			_onSimpleOverlayClosed: function() {
 				this.imageSelectorOpen = false;
 			},
-			_displaySetImageResult: function(success) {
+			_displaySetImageResult: function(success, forceImgRefresh) {
 				var overlayContent = this.$.overlayContent,
 					successClass = 'change-image-success',
 					failureClass = 'change-image-failure';
@@ -220,7 +241,7 @@
 					// Remove the icon after a bit of time
 					setTimeout(function() {
 						if (success) {
-							this._setBannerImage(this._nextImage);
+							this._setBannerImage(this._nextImage, forceImgRefresh);
 						}
 						this.toggleClass(successClass, false, overlayContent);
 						this.toggleClass(failureClass, false, overlayContent);
@@ -246,9 +267,11 @@
 				this.imageSelectorOpen = true;
 				this.$['basic-image-selector-overlay'].open();
 			},
-			_setBannerImage: function(image) {
+			_setBannerImage: function(image, forceImgRefresh) {
 				var bannerImage = document.querySelector('.d2l-course-banner .d2l-course-banner-image');
 				var imageSrc = this._getDefaultImageLink(image);
+
+				imageSrc = forceImgRefresh ? imageSrc + '#' + new Date().getTime() : imageSrc;
 
 				if (bannerImage && imageSrc) {
 					bannerImage.src = imageSrc;
@@ -263,6 +286,21 @@
 			},
 			_showDropdown: function(removeBannerAction, changeImageAction) {
 				return !!removeBannerAction || !!changeImageAction;
+			},
+			_onCourseImageResponse: function(response) {
+				var self = this;
+
+				if (!response.ok) {
+					self._displaySetImageResult(false);
+					return;
+				}
+
+				response
+					.json()
+					.then(function(bodyAsJson) {
+						self._nextImage = self._parseSiren(bodyAsJson);
+						self._displaySetImageResult(true, true);
+					});
 			},
 			_onOrganizationResponse: function(response) {
 				var self = this;
@@ -304,7 +342,20 @@
 							self._addPerfMark('org-response.rendered'); // eslint-disable-line no-invalid-this
 							self._addPerfMeasure('ready-to-org-response-displayed', 'ready', 'org-response.rendered'); // eslint-disable-line no-invalid-this
 						});
+
+						if (self._shouldRefreshCourseImage) {
+							self._refreshCourseImage(organization.getSubEntitiesByClass('course-image')[0].href);
+						}
 					});
+			},
+			_refreshCourseImage: function(courseImageApiUrl) {
+				window.d2lauthify
+					.fetch(new Request(courseImageApiUrl, {
+						headers: new Headers({
+							Accept: 'application/vnd.siren+json'
+						})
+					}))
+					.then(this._onCourseImageResponse.bind(this));
 			},
 			_toggleCourseBanner: function() {
 				var relevantAction = this._addBannerAction || this._removeBannerAction;

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -344,7 +344,7 @@
 						});
 
 						if (self._shouldRefreshCourseImage) {
-							self._refreshCourseImage(organization.getSubEntitiesByClass('course-image')[0].href);
+							self._refreshCourseImage(organization.getSubEntityByClass('course-image').href);
 						}
 					});
 			},

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -151,6 +151,7 @@
 			},
 			attached: function() {
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
+				this._getOrganizationInfo();
 			},
 			ready: function() {
 				this._addPerfMark('ready');
@@ -158,7 +159,6 @@
 				this._showBannerErrorAlert = false;
 				Polymer.dom(this.$.overlayContent).classList.add('d2l-image-banner-overlay-content-shown');
 				document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
-				this._getOrganizationInfo();
 			},
 			courseImageUploadCompleted: function(success) {
 				var overlayContent = this.$.overlayContent;


### PR DESCRIPTION
This passes along the new image upload callback to the image selector.  It also has a new focus function for the lms to call when it is done uploading a new course image, and a function "courseImageUploadCompleted" to also be called when done.

The image will be refreshed upon successful completion.  This means calling the API for the organization, getting the href for the image, and updating the images src.  This required appending a #datetimestamp to the end of the src link so that browsers wouldn't cache the image at that point.  I looked around online and this seemed to be the most reliable way to accomplish this across browsers, as even changing cache headers and stuff seemed to be inconsistently successful.

You'll see that the use of "_shouldRefreshCourseImage" is a bit awkward I admit (it controls whether the image should be refreshed after calling the organization api or not), but it was better IMO than some other approaches or heavy refactoring.