### PR TITLE
Switch to d2l-fetch from d2l-authify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: node_js
 node_js:
-- 5
+- 6
 sudo: false
-addons:
-  firefox: latest
-  apt:
-    packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
 before_script:
 - npm run test:lint:js
+- npm run test:lint:wc
 script:
 - xvfb-run wct

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-- 6
+node_js: node
 sudo: false
 before_script:
 - npm run test:lint:js

--- a/bower.json
+++ b/bower.json
@@ -30,11 +30,11 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-alert": "^2.0.0",
-    "d2l-authify-import": "https://github.com/Brightspace/d2l-authify-import.git#^0.4.0",
     "d2l-colors": "^2.3.0",
     "d2l-dropdown": "^5.0.6",
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
     "d2l-icons": "^3.2.0",
-    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^1.1.0",
+    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^2.0.1",
     "d2l-link": "^3.5.0",
     "d2l-loading-spinner": "^5.0.4",
     "d2l-menu": "^0.3.5",
@@ -53,5 +53,8 @@
     "iron-pages": "^1.0.8",
     "polymer": "^1.7.0",
     "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.1"
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "postinstall": "bower install",
-    "test": "npm run test:lint:js && wct",
+    "test": "npm run test:lint:js && test:lint:wc && polymer test",
     "test:lint:js": "eslint --ext .js,.html .",
-    "test:no-lint": "wct -p"
+    "test:lint:wc": "polymer lint",
+    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=chrome wct -p"
   },
   "homepage": "https://github.com/Brightspace/d2l-image-banner-overlay",
   "repository": {
@@ -26,11 +27,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "bower": "^1.7.7",
+    "cross-env": "^5.0.5",
     "eslint": "^2.4.0",
     "eslint-config-brightspace": "^0.2.1",
     "eslint-plugin-html": "^1.4.0",
-    "polylint": "^2.10.1",
+    "polymer-cli": "^1.5.6",
     "rimraf": "^2.5.2",
-    "web-component-tester": "^5.0.0"
+    "web-component-tester": "^6.0.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "rules": ["polymer-2-hybrid"]
+  }
+}

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
 <link rel="import" href="../../d2l-alert/d2l-alert.html">
-<link rel="import" href="../../d2l-authify-import/d2l-authify.html">
+<link rel="import" href="../../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
@@ -60,7 +60,6 @@
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
 			title-name="{{localize('changeImage')}}"
-			locale="[[locale]]"
 			close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}"
 			with-backdrop>
 			<iron-scroll-threshold
@@ -172,7 +171,7 @@
 				this.$$('button').focus();
 			},
 			_getOrganizationInfo: function() {
-				window.d2lauthify
+				window.d2lfetch
 					.fetch(new Request(this.organizationUrl, {
 						headers: new Headers({
 							Accept: 'application/vnd.siren+json'
@@ -245,19 +244,21 @@
 			},
 			_telemetryRequest: null,
 			_launchCourseTileImageSelector: function() {
-				this._telemetryRequest = this._telemetryRequest || document.createElement('d2l-ajax');
-				this._telemetryRequest.url = this.telemetryEndpoint;
-				this._telemetryRequest.method = 'POST';
-				this._telemetryRequest.headers = {
-					'content-type': 'application/json'
-				};
-				this._telemetryRequest.body = JSON.stringify({
+				var body = {
 					name: 'LaunchChangeImage',
 					ts: Math.round(Date.now() / 1000),
 					userId: this.userId,
 					tenantId: this.tenantId
-				});
-				this._telemetryRequest.generateRequest();
+				};
+
+				this._telemetryRequest = window.d2lfetch
+					.fetch(new Request(this.telemetryEndpoint, {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json'
+						},
+						body: JSON.stringify(body)
+					}));
 
 				this.imageSelectorOpen = true;
 				this.$['basic-image-selector-overlay'].open();
@@ -344,7 +345,7 @@
 					});
 			},
 			_refreshCourseImage: function(courseImageApiUrl) {
-				window.d2lauthify
+				window.d2lfetch
 					.fetch(new Request(courseImageApiUrl, {
 						headers: new Headers({
 							Accept: 'application/vnd.siren+json'
@@ -357,7 +358,7 @@
 				Polymer.dom(this.$.overlayContent).classList.add('loading-overlay-shown');
 
 				if (relevantAction) {
-					window.d2lauthify
+					window.d2lfetch
 						.fetch(new Request(relevantAction, {
 							method: 'PUT',
 							headers: new Headers({

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -2,53 +2,8 @@
   "plugins": {
     "local": {
       "browsers": [{
-        "browserName": "firefox"
+        "browserName": "chrome"
       }]
-    },
-    "sauce": {
-      "disabled": true,
-      "browsers": [
-        {
-          "browserName": "chrome",
-          "platform": "OS X 10.11",
-          "version": ""
-        },
-        {
-          "browserName": "chrome",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "firefox",
-          "platform": "OS X 10.11",
-          "version": ""
-        },
-        {
-          "browserName": "firefox",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "safari",
-          "platform": "OS X 10.11",
-          "version": "9.0"
-        },
-        {
-          "browserName": "microsoftedge",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "internet explorer",
-          "platform": "Windows 10",
-          "version": "11"
-        },
-        {
-          "browserName": "internet explorer",
-          "platform": "Windows 8",
-          "version": "10"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
These are more or less equivalent, but d2l-fetch is a more fleshed out approach, with middlewares and such. Note that this is a breaking change, as `d2l-image-banner-overlay` will now require the consumer to set up the appropriate middlewares; in particular, `d2l-fetch-auth` is required.