### PR TITLE
DE28347 Fix event names

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -127,8 +127,8 @@
 				window.D2L.Hypermedia.OrganizationHMBehavior
 			],
 			listeners: {
-				'alert-button-pressed': '_onAlertButtonPressed',
-				'alert-closed': '_onAlertClosed',
+				'd2l-alert-button-pressed': '_onAlertButtonPressed',
+				'd2l-alert-closed': '_onAlertClosed',
 				'clear-image-scroll-threshold': '_onClearImageScrollThreshold',
 				'd2l-simple-overlay-closed': '_onSimpleOverlayClosed'
 			},

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -28,7 +28,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.12",
-					"version": "11.0"
+					"version": ""
 				},
 				{
 					"browserName": "microsoftedge",


### PR DESCRIPTION
These events were renamed but were missed in the observers array.

Also, default to latest Safari on Sauce with an empty string.