### PR TITLE
Capajon/us93815 upload banner issues

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -324,6 +324,7 @@
 
 				if (this._shouldRefreshCourseImage) {
 					this._refreshCourseImage(organization.getSubEntityByClass('course-image').href);
+					this._refreshCourseImage(this._parseSiren(organization).getSubEntityByClass('course-image').href);
 				}
 			},
 			_refreshCourseImage: function(courseImageApiUrl) {

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -323,7 +323,6 @@
 				});
 
 				if (this._shouldRefreshCourseImage) {
-					this._refreshCourseImage(organization.getSubEntityByClass('course-image').href);
 					this._refreshCourseImage(this._parseSiren(organization).getSubEntityByClass('course-image').href);
 				}
 			},

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -174,11 +174,18 @@
 				this.$$('button').focus();
 			},
 			_getOrganizationInfo: function() {
+				var headerOptions = new Headers({
+					Accept: 'application/vnd.siren+json'
+				});
+
+				if (this._organization) {
+					headerOptions.append('pragma', 'no-cache');
+					headerOptions.append('cache-control', 'no-cache');
+				}
+
 				return window.d2lfetch
 					.fetch(new Request(this.organizationUrl, {
-						headers: new Headers({
-							Accept: 'application/vnd.siren+json'
-						})
+						headers: headerOptions
 					}))
 					.then(function(response) {
 						if (response.ok) {

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -179,7 +179,6 @@
 				});
 
 				if (this._organization) {
-					headerOptions.append('pragma', 'no-cache');
 					headerOptions.append('cache-control', 'no-cache');
 				}
 
@@ -269,7 +268,7 @@
 
 				if (forceImgRefresh) {
 					var separator = imageSrc.split('?')[1] ? '&' : '?';
-					imageSrc = imageSrc + separator + new Date().getTime();
+					imageSrc = imageSrc + separator + 'timestamp=' + new Date().getTime();
 				}
 
 				if (bannerImage && imageSrc) {
@@ -326,7 +325,7 @@
 				});
 
 				if (this._shouldRefreshCourseImage) {
-					this._refreshCourseImage(this._parseSiren(organization).getSubEntityByClass('course-image').href);
+					this._refreshCourseImage(organizationEntity.getSubEntityByClass('course-image').href);
 				}
 			},
 			_refreshCourseImage: function(courseImageApiUrl) {

--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -267,11 +267,14 @@
 				var bannerImage = document.querySelector('.d2l-course-banner .d2l-course-banner-image');
 				var imageSrc = this._getDefaultImageLink(image);
 
-				imageSrc = forceImgRefresh ? imageSrc + '#' + new Date().getTime() : imageSrc;
+				if (forceImgRefresh) {
+					var separator = imageSrc.split('?')[1] ? '&' : '?';
+					imageSrc = imageSrc + separator + new Date().getTime();
+				}
 
 				if (bannerImage && imageSrc) {
-					bannerImage.src = imageSrc;
 					bannerImage.srcset = '';
+					bannerImage.src = imageSrc;
 				}
 			},
 			_getDefaultImageLink: function(image) {


### PR DESCRIPTION
Few changes here:

- Fix where organization entity needs to be parsed into a siren entity (I think from the switch to d2l-fetch)
- If we are request org information a second time, I set some header options to not cache, which was important in order to get the right version of custom uploaded images
- instead of appending a date time stamp as a '#' - do it as a query param string.  There is basic check to see if this should be appended using ? or & - not completely comprehensive but it guards against whether or not the image URL has width params or not.