### PR TITLE
Close overlay when image is changed

### DIFF
--- a/src/d2l-image-banner-overlay.html
+++ b/src/d2l-image-banner-overlay.html
@@ -205,6 +205,8 @@
 				this.$['image-selector-threshold'].clearTriggers();
 			},
 			_onSetCourseImage: function(e) {
+				this.$['basic-image-selector-overlay'].close();
+
 				var org = this._parseSiren(e.detail.organization);
 				var orgSelfLink = (org.getLinkByRel('self') || {}).href || '';
 

--- a/test/d2l-image-banner-overlay.js
+++ b/test/d2l-image-banner-overlay.js
@@ -162,6 +162,20 @@ describe('d2l-image-banner-overlay', function() {
 
 				expect(JSON.stringify(component._nextImage)).to.equal('{"foo":"bar"}');
 			});
+
+			it('should close the image-selector overlay', function() {
+				var spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'close');
+
+				component._onSetCourseImage({
+					detail: {
+						status: 'set',
+						organization: {},
+						image: { foo: 'bar' }
+					}
+				});
+
+				expect(spy).to.have.been.called;
+			});
 		});
 	});
 


### PR DESCRIPTION
Previously, this was being accomplished by an event listener inside d2l-simple-overlay, but it was specific to this case. So, it will be removed from there, which means we have to explicitly close the overlay when a set-course-image event occurs.

(The change to `d2l-simple-overlay` to remove this behavior is in https://github.com/Brightspace/simple-overlay/pull/16, so this needs to merge + release before that merges + releases.)

See also https://github.com/Brightspace/d2l-my-courses-ui/pull/495.