### PR TITLE
fixing simple-overlays being under the backdrop in Polymer 2

### DIFF
--- a/d2l-image-banner-overlay-styles.html
+++ b/d2l-image-banner-overlay-styles.html
@@ -15,8 +15,8 @@
 				z-index: 1;
 				@apply --d2l-body-standard-text;
 			}
-			:host[image-selector-open] {
-				z-index: 1000;
+			:host([image-selector-open]) {
+				z-index: auto;
 			}
 
 			.d2l-image-banner-overlay-content {


### PR DESCRIPTION
A few things that are prompting this change:

First, the way the CSS rule is written, it wasn't ever getting applied -- it needed `:host([selector])` with the brackets.

With shadow DOM enabled, the fact that it wasn't getting applied combined with the `:host` having a `z-index` of `1` was causing `simple-overlay` (which just uses `iron-overlay-behavior` under the covers) to appear beneath the backdrop, despite having a higher z-index relative to the backdrop. That's because while its z-index was higher than the backdrop's, it having a parent with a z-index of 1, plus shadow DOM, confuses the browser.
