### PR TITLE
Close the menu on blur

### DIFF
--- a/d2l-image-banner-overlay.html
+++ b/d2l-image-banner-overlay.html
@@ -503,6 +503,15 @@ An overlay for course image banners that displays the course name and menu.
 			},
 			_onBlur: function() {
 				this.focused = false;
+				setTimeout(function() {
+					var activeElement = Polymer.dom(document.activeElement).node;
+					if (!D2L.Dom.isComposedAncestor(this, activeElement)) {
+						this._closeDropdown();
+					}
+				}.bind(this), 0);
+			},
+			_closeDropdown: function() {
+				if (this.$$('d2l-dropdown-menu').hasAttribute('opened')) this.$$('d2l-dropdown-more').toggleOpen();
 			}
 		});
 	</script>

--- a/d2l-image-banner-overlay.html
+++ b/d2l-image-banner-overlay.html
@@ -504,8 +504,7 @@ An overlay for course image banners that displays the course name and menu.
 			_onBlur: function() {
 				this.focused = false;
 				setTimeout(function() {
-					var activeElement = Polymer.dom(document.activeElement).node;
-					if (!D2L.Dom.isComposedAncestor(this, activeElement)) {
+					if (!D2L.Dom.isComposedAncestor(this, D2L.Dom.Focus.getComposedActiveElement())) {
 						this._closeDropdown();
 					}
 				}.bind(this), 0);


### PR DESCRIPTION
I based this on how the overflow menu was hidden in my courses, which I believe was based of d2l-menu a while ago.

https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-course-tile.html#L729

Tested Chrome/Firefox/Edge/Safari and Android/iOS and it works as expected.