### PR TITLE
fully hiding the overlay content

### DIFF
--- a/d2l-image-banner-overlay-styles.html
+++ b/d2l-image-banner-overlay-styles.html
@@ -20,6 +20,7 @@
 			}
 
 			.d2l-image-banner-overlay-content {
+				display: none;
 				height: 100%;
 				opacity: 0;
 				overflow: hidden;
@@ -30,6 +31,7 @@
 				animation-duration: 1.2s;
 				animation-fill-mode: forwards;
 				animation-name: shown;
+				display: block;
 			}
 
 			@keyframes shown {


### PR DESCRIPTION
The issue here is that `opacity: 0` makes it invisible, but it still takes up physical space and is still visible to screen readers. Also caused a strange bug in IE11 where the "..." menu was always visible even when the banner was removed.