### PR TITLE
Fix translations

### DIFF
--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -98,7 +98,7 @@
 							'undo': 'Ongedaan maken',
 							'somethingWentWrong': 'Oeps! Er is iets fout gegaan. {placeholder}.',
 							'refreshAndTryAgain': 'Vernieuw en probeer het opnieuw',
-							'changeImage': 'Change Image',
+							'changeImage': 'Afbeelding wijzigen',
 							'closeSimpleOverlayAltText': 'Dialoogvenster sluiten'
 						},
 						'pt': {

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -87,7 +87,7 @@
 							'undo': '실행 취소',
 							'somethingWentWrong': '문제가 발생했습니다. {placeholder}.',
 							'refreshAndTryAgain': '새로 고친 후 다시 시도하십시오.',
-							'changeImage': '',
+							'changeImage': '이미지 변경',
 							'closeSimpleOverlayAltText': '대화 상자 닫기'
 						},
 						'nl': {
@@ -98,7 +98,7 @@
 							'undo': 'Ongedaan maken',
 							'somethingWentWrong': 'Oeps! Er is iets fout gegaan. {placeholder}.',
 							'refreshAndTryAgain': 'Vernieuw en probeer het opnieuw',
-							'changeImage': '이미지 변경',
+							'changeImage': 'Change Image',
 							'closeSimpleOverlayAltText': 'Dialoogvenster sluiten'
 						},
 						'pt': {


### PR DESCRIPTION
Korean translation was moved into `ko` (was mistakenly placed in `nb`), and missing `nb` translation was taken from My Courses (same wording/context)