### PR TITLE
Update to latest dropdown and use visible-on-ancestor instead of cust…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "d2l-alert": "^3.1.0",
     "d2l-colors": "^3.1.2",
-    "d2l-dropdown": "^6.6.0",
+    "d2l-dropdown": "^6.6.1",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-icons": "^5.0.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^3.1.0",
@@ -39,7 +39,7 @@
     "d2l-localize-behavior": "^1.1.0",
     "d2l-menu": "^1.1.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.1",
-    "d2l-polymer-behaviors": "^1.7.2",
+    "d2l-polymer-behaviors": "^1.7.3",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^2.2.0",
     "d2l-typography": "^6.1.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "d2l-alert": "^3.1.0",
     "d2l-colors": "^3.1.2",
-    "d2l-dropdown": "^6.3.0",
+    "d2l-dropdown": "^6.6.0",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-icons": "^5.0.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^3.1.0",
@@ -39,7 +39,7 @@
     "d2l-localize-behavior": "^1.1.0",
     "d2l-menu": "^1.1.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.1",
-    "d2l-polymer-behaviors": "^1.3.0",
+    "d2l-polymer-behaviors": "^1.7.2",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^2.2.0",
     "d2l-typography": "^6.1.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^2.0.0",

--- a/d2l-image-banner-overlay-styles.html
+++ b/d2l-image-banner-overlay-styles.html
@@ -79,6 +79,7 @@
 			:host([department-banner-flag]) d2l-dropdown-more {
 				margin-left: 10px;
 				margin-right: 10px;
+				margin-top: 10px;
 			}
 
 			.loading-overlay-shown d2l-dropdown-more {
@@ -89,6 +90,7 @@
 				:host(:not([department-banner-flag])) d2l-dropdown-more {
 					margin-left: 30px;
 					margin-right: 30px;
+					margin-top: 30px;
 				}
 
 				:host-context([dir='rtl']) #courseName.menu-exists {
@@ -102,7 +104,11 @@
 			}
 
 			@media (max-width: 615px) {
-				:host(:not([department-banner-flag])) d2l-dropdown-more,
+				:host(:not([department-banner-flag])) d2l-dropdown-more {
+					margin-left: 15px;
+					margin-right: 15px;
+					margin-top: 15px;
+				}
 				#courseName {
 					margin-left: 15px;
 					margin-right: 15px;
@@ -110,12 +116,8 @@
 			}
 
 			d2l-dropdown-more {
-				padding-bottom: 0;
-				padding-top: 0;
 				position: absolute;
 				right: 0;
-				opacity: 0;
-				transition: opacity 0.25s, padding-top 0.25s;
 			}
 			d2l-dropdown-more[hidden] {
 				display: none;
@@ -123,16 +125,6 @@
 			:host-context([dir='rtl']) d2l-dropdown-more {
 				left: 0;
 				right: auto;
-			}
-
-			:host(:hover) d2l-dropdown-more,
-			:host([focused]) d2l-dropdown-more {
-				opacity: 1;
-				padding-top: 10px;
-			}
-			:host(:not([department-banner-flag])) d2l-dropdown-more {
-				opacity: 1;
-				padding-top: 30px;
 			}
 
 			:host-context([dir='rtl']) #courseName.menu-exists {

--- a/d2l-image-banner-overlay.html
+++ b/d2l-image-banner-overlay.html
@@ -28,7 +28,7 @@ An overlay for course image banners that displays the course name and menu.
 	<template strip-whitespace>
 		<style include="d2l-image-banner-overlay-styles"></style>
 
-		<div id="overlayContent" class="d2l-image-banner-overlay-content">
+		<div id="overlayContent" class="d2l-image-banner-overlay-content d2l-visible-on-ancestor-target">
 			<div class="d2l-image-banner-course-name-container">
 				<div class="d2l-image-banner-course-name">
 					<h1 id="courseName">[[_courseName]]</h1>
@@ -37,7 +37,9 @@ An overlay for course image banners that displays the course name and menu.
 			<d2l-dropdown-more
 				class="d2l-focusable"
 				hidden$="[[!_showDropdown]]"
-				label="[[localize('bannerSettings')]]">
+				label="[[localize('bannerSettings')]]"
+				translucent
+				visible-on-ancestor>
 				<d2l-dropdown-menu>
 					<d2l-menu label$="[[localize('bannerSettings')]]">
 						<d2l-menu-item
@@ -125,20 +127,13 @@ An overlay for course image banners that displays the course name and menu.
 				},
 				departmentBannerFlag: {
 					type: Boolean,
+					observer: '_onDepartmentBannerFlag',
 					value: false,
 					reflectToAttribute: true
 				},
 				homepageManageMenuFlag: {
 					type: Boolean,
 					value: false
-				},
-				/**
-				* A boolean reflecting the focus state of the element
-				*/
-				focused: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
 				},
 				_courseName: String, // the name to display in the main text area of the overlay
 				_removeBannerUrl: String, // the URL of the siren action to be executed when the remove banner menu option is clicked
@@ -188,12 +183,10 @@ An overlay for course image banners that displays the course name and menu.
 				'd2l-alert-closed': '_onAlertClosed',
 				'clear-image-scroll-threshold': '_onClearImageScrollThreshold',
 				'd2l-simple-overlay-closed': '_onSimpleOverlayClosed',
-				'focus': '_onFocus',
 				'blur': '_onBlur'
 			},
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					this.addEventListener('focus', this._onFocus, true);
 					this.addEventListener('blur', this._onBlur, true);
 				}.bind(this));
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
@@ -203,7 +196,6 @@ An overlay for course image banners that displays the course name and menu.
 				this.listen(document.body, 'set-course-image', '_onSetCourseImage');
 			},
 			detached: function() {
-				this.removeEventListener('focus', this._onFocus, true);
 				this.removeEventListener('blur', this._onBlur, true);
 				this.unlisten(document.body, 'set-course-image', '_onSetCourseImage');
 			},
@@ -255,6 +247,14 @@ An overlay for course image banners that displays the course name and menu.
 			},
 			_onClearImageScrollThreshold: function() {
 				this.$['image-selector-threshold'].clearTriggers();
+			},
+			_onDepartmentBannerFlag: function(newValue) {
+				var opener = Polymer.dom(this.root).querySelector('d2l-dropdown-more');
+				if (newValue) {
+					opener.setAttribute('visible-on-ancestor', 'visible-on-ancestor');
+				} else {
+					opener.removeAttribute('visible-on-ancestor');
+				}
 			},
 			_onSetCourseImage: function(e) {
 				this.$['basic-image-selector-overlay'].close();
@@ -503,11 +503,7 @@ An overlay for course image banners that displays the course name and menu.
 					);
 				}
 			},
-			_onFocus: function() {
-				this.focused = true;
-			},
 			_onBlur: function() {
-				this.focused = false;
 				setTimeout(function() {
 					if (!D2L.Dom.isComposedAncestor(this, D2L.Dom.Focus.getComposedActiveElement())) {
 						this._closeDropdown();

--- a/demo/index.html
+++ b/demo/index.html
@@ -33,7 +33,7 @@
 			<demo-snippet>
 				<template>
 					<demo-image-banner-container class="d2l-course-banner-container">
-						<d2l-image-banner-overlay organization-url="/default" has-change-image></d2l-image-banner-overlay>
+						<d2l-image-banner-overlay organization-url="/default" department-banner-flag has-change-image></d2l-image-banner-overlay>
 					</demo-image-banner-container>
 				</template>
 			</demo-snippet>

--- a/test/d2l-image-banner-overlay.js
+++ b/test/d2l-image-banner-overlay.js
@@ -289,30 +289,14 @@ describe('d2l-image-banner-overlay', function() {
 		describe('when the department-banner-flag is off', () => {
 			it('should appear without hover or focus', () => {
 				component.departmentBannerFlag = false;
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('padding-top')).to.equal('30px');
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('opacity')).to.equal('1');
-			});
-
-			it('should appear with focus/hover too', () => {
-				component.departmentBannerFlag = false;
-				component._onFocus();
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('padding-top')).to.equal('30px');
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('opacity')).to.equal('1');
+				expect(component.$$('d2l-dropdown-more').hasAttribute('visible-on-ancestor')).to.equal(false);
 			});
 		});
 
 		describe('when the department-banner-flag is on', () => {
 			it('should not appear without hover or focus', () => {
 				component.departmentBannerFlag = true;
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('padding-top')).to.equal('0px');
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('opacity')).to.equal('0');
-			});
-
-			it('should appear on focus/hover', () => {
-				component.departmentBannerFlag = true;
-				component._onFocus();
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('padding-top')).to.equal('10px');
-				expect(window.getComputedStyle(component.$$('d2l-dropdown-more'), null).getPropertyValue('opacity')).to.equal('1');
+				expect(component.$$('d2l-dropdown-more').hasAttribute('visible-on-ancestor')).to.equal(true);
 			});
 		});
 


### PR DESCRIPTION
Update to latest dropdown and use visible-on-ancestor instead of custom logic.

* use dropdown opener's translucent option
* use dropdown opener's visible-on-ancestor behavior to show/hide 
* remove custom styles and logic for showing/hiding the dropdown-more opener
